### PR TITLE
Allow integers in Gorilla stream validation

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@
 
 **Symptoms:**
 
-- `{:error, "Invalid data format: expected {timestamp, float} tuple"}`
+- `{:error, "Invalid data format: expected {timestamp, number} tuple"}`
 - `{:error, "Invalid input data"}`
 
 **Causes:**
@@ -281,7 +281,7 @@ GorillaStream.compress(%{data: "map"})
 GorillaStream.compress([{1609459200, 23.5}])
 ```
 
-### "Invalid data format: expected {timestamp, float} tuple"
+### "Invalid data format: expected {timestamp, number} tuple"
 
 **Cause:** Wrong tuple structure or data types
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -341,11 +341,11 @@ end
   GorillaStream.Compression.Gorilla.compress("not_a_list", false)
 
 # Invalid tuple structure
-{:error, "Invalid data format: expected {timestamp, float} tuple"} =
+{:error, "Invalid data format: expected {timestamp, number} tuple"} =
   GorillaStream.Compression.Gorilla.compress([{1, 2, 3}], false)
 
 # Non-numeric values
-{:error, "Invalid data format: expected {timestamp, float} tuple"} =
+{:error, "Invalid data format: expected {timestamp, number} tuple"} =
   GorillaStream.Compression.Gorilla.compress([{1, "invalid"}], false)
 ```
 
@@ -516,7 +516,7 @@ end
 | -------------------------------------- | ------------------------- | ----------------------------------------- |
 | "Invalid input data"                   | Non-list input            | Pass a list of tuples                     |
 | "Invalid data format"                  | Wrong tuple structure     | Use `{timestamp, value}` format           |
-| "expected {timestamp, float} tuple"    | Wrong data types          | Ensure integer timestamps, numeric values |
+| "expected {timestamp, number} tuple"   | Wrong data types          | Ensure integer timestamps, numeric values |
 | "Insufficient data for initial values" | Corrupted compressed data | Check data integrity                      |
 
 ## Examples

--- a/lib/gorilla_stream/compression/gorilla.ex
+++ b/lib/gorilla_stream/compression/gorilla.ex
@@ -2,7 +2,7 @@ defmodule GorillaStream.Compression.Gorilla do
   @moduledoc """
   Implements Gorilla compression for time series data streams.
 
-  This module provides compression for streams of {timestamp, float} data using
+  This module provides compression for streams of {timestamp, number} data using
   the Gorilla compression algorithm, with optional Zlib compression for additional
   compression at the final step.
 
@@ -13,10 +13,10 @@ defmodule GorillaStream.Compression.Gorilla do
   alias GorillaStream.Compression.Gorilla.{Encoder, Decoder}
 
   @doc """
-  Compresses a stream of {timestamp, float} data using the Gorilla algorithm.
+  Compresses a stream of {timestamp, number} data using the Gorilla algorithm.
 
   ## Parameters
-  - `stream`: An enumerable of {timestamp, float} tuples
+  - `stream`: An enumerable of {timestamp, number} tuples
   - `zlib_compression?`: Boolean flag to enable Zlib compression on the final output (default: false)
 
   ## Returns
@@ -104,18 +104,19 @@ defmodule GorillaStream.Compression.Gorilla do
       :ok
 
       iex> GorillaStream.Compression.Gorilla.validate_stream([{1609459200, "invalid"}])
-      {:error, "Invalid data format: expected {timestamp, float} tuple"}
+      {:error, "Invalid data format: expected {timestamp, number} tuple"}
   """
   def validate_stream(stream) do
     case Enum.all?(stream, &is_valid_data_tuple?/1) do
       true -> :ok
-      false -> {:error, "Invalid data format: expected {timestamp, float} tuple"}
+      false -> {:error, "Invalid data format: expected {timestamp, number} tuple"}
     end
   end
 
   # Private functions
 
-  defp is_valid_data_tuple?({timestamp, value}) when is_integer(timestamp) and is_float(value) do
+  defp is_valid_data_tuple?({timestamp, value})
+       when is_integer(timestamp) and (is_float(value) or is_integer(value)) do
     true
   end
 

--- a/test/gorilla_stream/compression/gorilla_compression_test.exs
+++ b/test/gorilla_stream/compression/gorilla_compression_test.exs
@@ -109,7 +109,7 @@ defmodule GorillaStream.Compression.GorillaCompressionTest do
   test "compress/2 returns error for invalid stream format" do
     invalid_stream = [{1_609_459_200, "invalid"}, {1_609_459_201, 1.24}]
 
-    assert {:error, "Invalid data format: expected {timestamp, float} tuple"} =
+    assert {:error, "Invalid data format: expected {timestamp, number} tuple"} =
              Gorilla.compress(invalid_stream, false)
   end
 
@@ -122,7 +122,7 @@ defmodule GorillaStream.Compression.GorillaCompressionTest do
   test "compress/2 returns error for invalid data type" do
     invalid_stream = [{1_609_459_200, 1.23}, {1_609_459_201, :invalid}]
 
-    assert {:error, "Invalid data format: expected {timestamp, float} tuple"} =
+    assert {:error, "Invalid data format: expected {timestamp, number} tuple"} =
              Gorilla.compress(invalid_stream, false)
   end
 
@@ -153,13 +153,13 @@ defmodule GorillaStream.Compression.GorillaCompressionTest do
     invalid_stream2 = [{1_609_459_200, 1.23}, {"invalid", 1.24}]
     invalid_stream3 = [1.23, 1.24]
 
-    assert {:error, "Invalid data format: expected {timestamp, float} tuple"} =
+    assert {:error, "Invalid data format: expected {timestamp, number} tuple"} =
              Gorilla.validate_stream(invalid_stream1)
 
-    assert {:error, "Invalid data format: expected {timestamp, float} tuple"} =
+    assert {:error, "Invalid data format: expected {timestamp, number} tuple"} =
              Gorilla.validate_stream(invalid_stream2)
 
-    assert {:error, "Invalid data format: expected {timestamp, float} tuple"} =
+    assert {:error, "Invalid data format: expected {timestamp, number} tuple"} =
              Gorilla.validate_stream(invalid_stream3)
   end
 


### PR DESCRIPTION
## Summary
- Accept integers as valid values in `GorillaStream.Compression.Gorilla.validate_stream`
- Update error messaging, documentation, and tests to expect `{timestamp, number}` tuples

## Testing
- `mix test` *(fails: Could not find an SCM for dependency :dialyxir from GorillaStream.MixProject)*

------
https://chatgpt.com/codex/tasks/task_e_68951a38aa5c832d91a981854592a9af