### PR TITLE
[codex] Fix Elixir 1.20 warnings

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -24,19 +24,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Erlang & Elixir (Linux)
-        if: runner.os == 'Linux'
+      - name: Normalize ARM Linux image name
+        if: matrix.runner == 'ubuntu-24.04-arm'
+        run: echo "ImageOS=ubuntu24" >> "$GITHUB_ENV"
+
+      - name: Install Erlang & Elixir
         uses: erlef/setup-beam@v1
         with:
           otp-version: "27"
           elixir-version: "1.19"
-
-      - name: Install Erlang & Elixir (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install erlang elixir
-          mix local.hex --force
-          mix local.rebar --force
 
       - name: Fetch dependencies
         run: mix deps.get

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -1,6 +1,7 @@
 name: Precompile NIF binaries
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"
@@ -53,6 +54,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/lib/gorilla_stream/compression/decoder/bit_unpacking.ex
+++ b/lib/gorilla_stream/compression/decoder/bit_unpacking.ex
@@ -104,12 +104,12 @@ defmodule GorillaStream.Compression.Decoder.BitUnpacking do
         if remaining_bits >= total_bits do
           # Extract all remaining data as bitstring, then take what we need
           <<all_bits::bitstring>> = remaining_data
-          <<data_bits::bitstring-size(total_bits), _padding::bitstring>> = all_bits
+          <<data_bits::bitstring-size(^total_bits), _padding::bitstring>> = all_bits
 
           # Split into timestamp and value components
           <<
-            timestamp_bits::bitstring-size(timestamp_bits_len),
-            value_bits::bitstring-size(value_bits_len)
+            timestamp_bits::bitstring-size(^timestamp_bits_len),
+            value_bits::bitstring-size(^value_bits_len)
           >> = data_bits
 
           {:ok, timestamp_bits, value_bits}

--- a/lib/gorilla_stream/compression/decoder/metadata.ex
+++ b/lib/gorilla_stream/compression/decoder/metadata.ex
@@ -175,7 +175,7 @@ defmodule GorillaStream.Compression.Decoder.Metadata do
       value_metadata: value_metadata
     }
 
-    <<compressed_data::binary-size(compressed_size), _rest::binary>> = data
+    <<compressed_data::binary-size(^compressed_size), _rest::binary>> = data
     {:ok, metadata, compressed_data}
   end
 

--- a/lib/gorilla_stream/compression/decoder/value_decompression.ex
+++ b/lib/gorilla_stream/compression/decoder/value_decompression.ex
@@ -130,7 +130,7 @@ defmodule GorillaStream.Compression.Decoder.ValueDecompression do
 
     if meaningful_length > 0 do
       case rest do
-        <<meaningful_value::size(meaningful_length), remaining_bits::bitstring>> ->
+        <<meaningful_value::size(^meaningful_length), remaining_bits::bitstring>> ->
           # Reconstruct XOR result
           xor_result = meaningful_value <<< state.prev_trailing_zeros
 
@@ -163,7 +163,7 @@ defmodule GorillaStream.Compression.Decoder.ValueDecompression do
 
         if meaningful_length > 0 and meaningful_length <= 64 do
           case remaining_bits do
-            <<meaningful_value::size(meaningful_length), final_bits::bitstring>> ->
+            <<meaningful_value::size(^meaningful_length), final_bits::bitstring>> ->
               # Calculate trailing zeros
               trailing_zeros = 64 - leading_zeros - meaningful_length
 

--- a/lib/gorilla_stream/compression/encoder/bit_packing.ex
+++ b/lib/gorilla_stream/compression/encoder/bit_packing.ex
@@ -161,11 +161,11 @@ defmodule GorillaStream.Compression.Encoder.BitPacking do
         total_data_bytes = div(total_data_bits + 7, 8)
 
         if byte_size(remaining) >= total_data_bytes do
-          <<data_bits::bitstring-size(total_data_bits), _padding::binary>> = remaining
+          <<data_bits::bitstring-size(^total_data_bits), _padding::binary>> = remaining
 
           <<
-            timestamp_bits::bitstring-size(timestamp_bits_len),
-            value_bits::bitstring-size(value_bits_len)
+            timestamp_bits::bitstring-size(^timestamp_bits_len),
+            value_bits::bitstring-size(^value_bits_len)
           >> = data_bits
 
           # Reconstruct metadata

--- a/lib/gorilla_stream/compression/encoder/bit_writer.ex
+++ b/lib/gorilla_stream/compression/encoder/bit_writer.ex
@@ -26,12 +26,13 @@ defmodule GorillaStream.Compression.Encoder.BitWriter do
   @spec write_bits(t(), bitstring()) :: t()
   def write_bits(%__MODULE__{} = w, bits) when is_bitstring(bits) do
     size = bit_size(bits)
-    <<value::size(size)>> = bits
+    <<value::size(^size)>> = bits
     write(w, value, size)
   end
 
   defp flush(%__MODULE__{bits: bits} = w) when bits >= 8 do
-    <<byte::8, rest::size(bits - 8)>> = <<w.buf::size(bits)>>
+    rest_bits = bits - 8
+    <<byte::8, rest::size(^rest_bits)>> = <<w.buf::size(bits)>>
     flush(%{w | acc: [w.acc, byte], buf: rest, bits: bits - 8})
   end
 

--- a/lib/gorilla_stream/compression/encoder/delta_encoding.ex
+++ b/lib/gorilla_stream/compression/encoder/delta_encoding.ex
@@ -28,10 +28,6 @@ defmodule GorillaStream.Compression.Encoder.DeltaEncoding do
     {:error, "Input must be a list of integers"}
   end
 
-  def encode(timestamps) when not is_list(timestamps) do
-    {:error, "Input must be a list of integers"}
-  end
-
   def encode([]), do: {<<>>, %{count: 0}}
 
   def encode([timestamp]) when is_integer(timestamp) do

--- a/lib/gorilla_stream/validator.ex
+++ b/lib/gorilla_stream/validator.ex
@@ -6,6 +6,8 @@ defmodule GorillaStream.Validator do
   data before compression.
   """
 
+  @max_finite_float 1.7976931348623157e308
+
   @doc """
   Validates time series data and reports any issues.
 
@@ -126,11 +128,10 @@ defmodule GorillaStream.Validator do
   defp validate_point(_), do: {:error, :invalid_format}
 
   defp is_finite_number(value) when is_float(value) do
-    not (value != value or value == :infinity or value == :neg_infinity)
+    value == value and value > -@max_finite_float and value < @max_finite_float
   end
 
   defp is_finite_number(value) when is_integer(value), do: true
-  defp is_finite_number(_), do: false
 
   defp check_timestamp_ordering(data, issues) do
     timestamps = Enum.map(data, fn {ts, _} -> ts end)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule GorillaStream.MixProject do
   use Mix.Project
 
-  @version "3.0.1"
+  @version "3.0.2"
 
   def project do
     [

--- a/test/gorilla_stream/compression/gorilla/decoder_test.exs
+++ b/test/gorilla_stream/compression/gorilla/decoder_test.exs
@@ -188,7 +188,7 @@ defmodule GorillaStream.Compression.Gorilla.DecoderTest do
 
       # Truncate the data
       truncated_size = div(byte_size(encoded_data), 2)
-      <<truncated_data::binary-size(truncated_size), _rest::binary>> = encoded_data
+      <<truncated_data::binary-size(^truncated_size), _rest::binary>> = encoded_data
 
       # Truncated data may result in empty data extraction
       assert {:ok, []} = Decoder.decode(truncated_data)
@@ -269,7 +269,7 @@ defmodule GorillaStream.Compression.Gorilla.DecoderTest do
 
       # Truncate the data
       truncated_size = div(byte_size(encoded_data), 3)
-      <<truncated_data::binary-size(truncated_size), _rest::binary>> = encoded_data
+      <<truncated_data::binary-size(^truncated_size), _rest::binary>> = encoded_data
 
       # Validation may pass or fail depending on how truncation affects metadata
       case Decoder.validate_compressed_data(truncated_data) do
@@ -1023,7 +1023,7 @@ defmodule GorillaStream.Compression.Gorilla.DecoderTest do
     safe_length = min(length, data_size - safe_start)
 
     if safe_length > 0 do
-      <<prefix::binary-size(safe_start), _corrupted::binary-size(safe_length), suffix::binary>> =
+      <<prefix::binary-size(^safe_start), _corrupted::binary-size(^safe_length), suffix::binary>> =
         data
 
       corrupted_bytes = :binary.copy(<<255>>, safe_length)

--- a/test/gorilla_stream/compression/gorilla/encoder_test.exs
+++ b/test/gorilla_stream/compression/gorilla/encoder_test.exs
@@ -402,7 +402,7 @@ defmodule GorillaStream.Compression.Gorilla.EncoderTest do
       ]
 
       assert {:ok, ratio} = Encoder.estimate_compression_ratio(data)
-      assert is_float(ratio) and ratio <= 1.0
+      assert ratio <= 1.0
     end
 
     test "handles single and two-point lists in estimation" do


### PR DESCRIPTION
## Summary

- Fix Elixir 1.20 compiler warnings in bitstring matches and validation code.
- Bump the package version to 3.0.2.
- Fix the precompile workflow for ARM Linux and macOS, and allow manual precompile validation without running release publishing.

## Validation

- mix compile --force
- mix test
- Manual Precompile NIF binaries workflow: https://github.com/awksedgreep/gorilla_stream/actions/runs/28304175980